### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,9 @@ setuptools.setup(
     project_urls={
         "Bug Tracker": "https://github.com/minwook-shin/notion-database/issues",
     },
+    install_requires=[
+     "requests==2.25.1"
+    ]
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",


### PR DESCRIPTION
Hi @minwook-shin . I am building a library on top of yours and it looks liked you missed adding your requirements to `install_require` array in `setup.py`. This leads to the `requests` library not being installed when you `pip install` the library. If you want to see the effect this change has you can run the cmds below in a `venv`.  

`python3 -m venv venv`
`/venv/bin/pip3 install git+https://github.com/potofpie/notion-database/tree/potofpie-patch-1#egg=notion_database`