### PR TITLE
Add support for `is_inline` param to `create_database` function

### DIFF
--- a/notion_database/database.py
+++ b/notion_database/database.py
@@ -99,7 +99,7 @@ class Database:
         self.result = self.request.call_api_get(url)
 
     def create_database(self, page_id: str, title:str,
-                        properties: Properties = None, cover: Cover = None, icon: Icon = None):
+                        properties: Properties = None, cover: Cover = None, icon: Icon = None, is_inline: bool = False):
         """
         Create a database
 
@@ -108,6 +108,7 @@ class Database:
         :param properties: Property schema of database
         :param cover:
         :param icon:
+        :param is_inline: Shows the database inline of the parent page
         :return:
         """
         if properties is None:
@@ -117,6 +118,7 @@ class Database:
                 "type": "page_id",
                 "page_id": page_id
             },
+            "is_inline": is_inline,
             "title": [
                 {
                     "type": "text",


### PR DESCRIPTION
Notion API now supports creating new databases as [inline of parent pages](https://developers.notion.com/reference/database#:~:text=false-,is_inline,-boolean) via the `is_inline` parameter in body of the request. 
This PR adds the `is_inline` parameter to `create_database` function, set to False by default